### PR TITLE
Feature: Query retries for StateStoreQueryActor implementations

### DIFF
--- a/src/main/java/io/vlingo/xoom/lattice/query/StateStoreQueryActor.java
+++ b/src/main/java/io/vlingo/xoom/lattice/query/StateStoreQueryActor.java
@@ -113,8 +113,8 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
    * @return {@code Completes<ObjectState<T>>}
    */
   @SuppressWarnings("unchecked")
-  protected <T> Completes<ObjectState<T>> queryObjectStateWithRetriesFor(final String id, final Class<T> type, final int retryInterval, final int retryTotal) {
-    return queryObjectStateWithRetriesFor(id, type, null, retryInterval, retryTotal);
+  protected <T> Completes<ObjectState<T>> queryObjectStateFor(final String id, final Class<T> type, final int retryInterval, final int retryTotal) {
+    return queryObjectStateFor(id, type, null, retryInterval, retryTotal);
   }
 
   /**
@@ -139,7 +139,7 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
    * @return {@code Completes<ObjectState<T>>}
    */
   @SuppressWarnings("unchecked")
-  protected <T> Completes<ObjectState<T>> queryObjectStateWithRetriesFor(final String id, final Class<T> type, final ObjectState<T> notFoundState, final int retryInterval, final int retryTotal) {
+  protected <T> Completes<ObjectState<T>> queryObjectStateFor(final String id, final Class<T> type, final ObjectState<T> notFoundState, final int retryInterval, final int retryTotal) {
     queryWithRetries(new RetryContext<T>(completesEventually(), (answer) -> queryFor(id, type, QueryResultHandler.ResultType.ObjectState, (T) notFoundState, answer), (T) notFoundState, retryInterval, retryTotal));
     return completes();
   }
@@ -201,8 +201,8 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
    * @param <T> the type of the state
    * @return {@code Completes<T>}
    */
-  protected <T> Completes<T> queryStateWithRetriesFor(final String id, final Class<T> type, final int retryInterval, final int retryTotal) {
-    return queryStateWithRetriesFor(id, type, null, retryInterval, retryTotal);
+  protected <T> Completes<T> queryStateFor(final String id, final Class<T> type, final int retryInterval, final int retryTotal) {
+    return queryStateFor(id, type, null, retryInterval, retryTotal);
   }
 
   /**
@@ -223,7 +223,7 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
    * @param <T> the type of the state
    * @return {@code Completes<T>}
    */
-  protected <T> Completes<T> queryStateWithRetriesFor(final String id, final Class<T> type, final T notFoundState, final int retryInterval, final int retryTotal) {
+  protected <T> Completes<T> queryStateFor(final String id, final Class<T> type, final T notFoundState, final int retryInterval, final int retryTotal) {
     queryWithRetries(new RetryContext<T>(completesEventually(), (answer) -> queryFor(id, type, QueryResultHandler.ResultType.Unwrapped, notFoundState, answer), notFoundState, retryInterval, retryTotal));
     return completes();
   }

--- a/src/main/java/io/vlingo/xoom/lattice/query/StateStoreQueryActor.java
+++ b/src/main/java/io/vlingo/xoom/lattice/query/StateStoreQueryActor.java
@@ -45,7 +45,7 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
   }
 
   @Override
-  public void intervalSignal(Scheduled<RetryContext> scheduled, RetryContext context) {
+  public void intervalSignal(final Scheduled<RetryContext> scheduled, final RetryContext context) {
     queryWithRetries(context);
   }
 
@@ -228,7 +228,7 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
     return completes();
   }
 
-  private <T> void queryWithRetries(RetryContext context) {
+  private <T> void queryWithRetries(final RetryContext context) {
     final Consumer<T> answer = (maybeFoundState) -> {
       if (context.needsRetry(maybeFoundState)) {
         scheduler().scheduleOnce(selfAs(Scheduled.class), context.nextTry(), 0, context.retryInterval);
@@ -327,11 +327,11 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
   }
 
   static final class RetryContext<T> {
-    public final CompletesEventually completes;
-    public final Consumer<Consumer<T>> query;
-    public final T notFoundState;
-    public final int retryInterval;
-    public final int retriesLeft;
+    private final CompletesEventually completes;
+    private final Consumer<Consumer<T>> query;
+    private final T notFoundState;
+    private final int retryInterval;
+    private final int retriesLeft;
 
     public RetryContext(final CompletesEventually completes, final Consumer<Consumer<T>> query, final T notFoundState, final int retryInterval, final int retriesLeft) {
       this.completes = completes;
@@ -341,11 +341,11 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
       this.retriesLeft = retriesLeft;
     }
 
-    public RetryContext<T> nextTry() {
+    private RetryContext<T> nextTry() {
       return new RetryContext(completes, query, notFoundState, retryInterval, retriesLeft - 1);
     }
 
-    public <T> boolean needsRetry(T maybeFoundState) {
+    private <T> boolean needsRetry(final T maybeFoundState) {
       return retriesLeft > 0 && Objects.equals(maybeFoundState, notFoundState);
     }
   }

--- a/src/main/java/io/vlingo/xoom/lattice/query/StateStoreQueryActor.java
+++ b/src/main/java/io/vlingo/xoom/lattice/query/StateStoreQueryActor.java
@@ -7,13 +7,11 @@
 
 package io.vlingo.xoom.lattice.query;
 
-import java.util.Collection;
-import java.util.function.Consumer;
-
 import io.vlingo.xoom.actors.Actor;
 import io.vlingo.xoom.actors.CompletesEventually;
 import io.vlingo.xoom.common.Completes;
 import io.vlingo.xoom.common.Outcome;
+import io.vlingo.xoom.common.Scheduled;
 import io.vlingo.xoom.lattice.CompositeIdentitySupport;
 import io.vlingo.xoom.reactivestreams.sink.TerminalOperationConsumerSink;
 import io.vlingo.xoom.symbio.Metadata;
@@ -24,10 +22,14 @@ import io.vlingo.xoom.symbio.store.StorageException;
 import io.vlingo.xoom.symbio.store.state.StateStore;
 import io.vlingo.xoom.symbio.store.state.StateStore.ReadResultInterest;
 
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Consumer;
+
 /**
  * A building-block {@code Actor} that queries asynchronously for state by id.
  */
-public abstract class StateStoreQueryActor extends Actor implements CompositeIdentitySupport, ReadResultInterest {
+public abstract class StateStoreQueryActor extends Actor implements CompositeIdentitySupport, ReadResultInterest, Scheduled<StateStoreQueryActor.RetryContext> {
 
   private final ReadResultInterest readInterest;
   private final StateStore stateStore;
@@ -40,6 +42,11 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
   protected StateStoreQueryActor(final StateStore stateStore) {
     this.stateStore = stateStore;
     this.readInterest = selfAs(ReadResultInterest.class);
+  }
+
+  @Override
+  public void intervalSignal(Scheduled<RetryContext> scheduled, RetryContext context) {
+    queryWithRetries(context);
   }
 
   /**
@@ -124,6 +131,62 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
     return queryFor(id, type, QueryResultHandler.ResultType.Unwrapped, notFoundState);
   }
 
+
+  /**
+   * Answer a {@code Completes<T>} of the eventual result of querying
+   * for the state of the {@code type} identified by {@code id}.
+   *
+   * <p>If the state is found, the outcome is the {@code T} instance.
+   *
+   * <p>If the state is not found, the outcome is {@code null}.
+   *
+   * <p>If the state is not found, the query will be retried up to {@code retryTotal} times in {@code retryInterval} intervals.
+   *
+   * @param id the String unique identity of the state to query
+   * @param type the {@code Class<T>} type of the state to query
+   * @param retryInterval the interval for retries if state is not found at first
+   * @param retryTotal the maximum number of retries if state is not found at first
+   * @param <T> the type of the state
+   * @return {@code Completes<T>}
+   */
+  protected <T> Completes<T> queryStateWithRetriesFor(final String id, final Class<T> type, final int retryInterval, final int retryTotal) {
+    return queryStateWithRetriesFor(id, type, null, retryInterval, retryTotal);
+  }
+
+  /**
+   * Answer a {@code Completes<T>} of the eventual result of querying
+   * for the state of the {@code type} identified by {@code id}.
+   *
+   * <p>If the state is found, the outcome is the {@code T} instance.
+   *
+   * <p>If the state is not found, the outcome is {@code notFoundState}.
+   *
+   * <p>If the state is not found, the query will be retried up to {@code retryTotal} times in {@code retryInterval} intervals.
+   *
+   * @param id the String unique identity of the state to query
+   * @param type the {@code Class<T>} type of the state to query
+   * @param notFoundState the T state to answer if the query doesn't find the desired state
+   * @param retryInterval the interval for retries if state is not found at first
+   * @param retryTotal the maximum number of retries if state is not found at first
+   * @param <T> the type of the state
+   * @return {@code Completes<T>}
+   */
+  protected <T> Completes<T> queryStateWithRetriesFor(final String id, final Class<T> type, final T notFoundState, final int retryInterval, final int retryTotal) {
+    queryWithRetries(new RetryContext<T>(completesEventually(), (answer) -> queryFor(id, type, QueryResultHandler.ResultType.Unwrapped, notFoundState, answer), notFoundState, retryInterval, retryTotal));
+    return completes();
+  }
+
+  private <T> void queryWithRetries(RetryContext context) {
+    final Consumer<T> answer = (maybeFoundState) -> {
+      if (context.needsRetry(maybeFoundState)) {
+        scheduler().scheduleOnce(selfAs(Scheduled.class), context.nextTry(), 0, context.retryInterval);
+      } else {
+        context.completes.with(maybeFoundState);
+      }
+    };
+    context.query.accept(answer);
+  }
+
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private <T, R> Completes<Collection<R>> queryAllOf(final Class<T> type, final Collection<R> all) {
     final Consumer<StateBundle> populator = (StateBundle state) -> {
@@ -145,9 +208,12 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
 
   private <T> Completes<T> queryFor(final String id, final Class<T> type, final QueryResultHandler.ResultType resultType, final T notFoundState) {
     final CompletesEventually completes = completesEventually();
-    final Consumer<T> answer = (maybeFoundState) -> completes.with(maybeFoundState);
-    stateStore.read(id, type, readInterest, new QueryResultHandler<>(answer, resultType, notFoundState));
+    queryFor(id, type, resultType, notFoundState, (T maybeFoundState) -> completes.with(maybeFoundState));
     return completes();
+  }
+
+  private <T> void queryFor(final String id, final Class<T> type, final QueryResultHandler.ResultType resultType, final T notFoundState, final Consumer<T> answer) {
+    stateStore.read(id, type, readInterest, new QueryResultHandler<>(answer, resultType, notFoundState));
   }
 
   //==================================
@@ -205,6 +271,30 @@ public abstract class StateStoreQueryActor extends Actor implements CompositeIde
         consumer.accept(state);
         break;
       }
+    }
+  }
+
+  static final class RetryContext<T> {
+    public final CompletesEventually completes;
+    public final Consumer<Consumer<T>> query;
+    public final T notFoundState;
+    public final int retryInterval;
+    public final int retriesLeft;
+
+    public RetryContext(final CompletesEventually completes, final Consumer<Consumer<T>> query, final T notFoundState, final int retryInterval, final int retriesLeft) {
+      this.completes = completes;
+      this.query = query;
+      this.notFoundState = notFoundState;
+      this.retryInterval = retryInterval;
+      this.retriesLeft = retriesLeft;
+    }
+
+    public RetryContext<T> nextTry() {
+      return new RetryContext(completes, query, notFoundState, retryInterval, retriesLeft - 1);
+    }
+
+    public <T> boolean needsRetry(T maybeFoundState) {
+      return retriesLeft > 0 && Objects.equals(maybeFoundState, notFoundState);
     }
   }
 }

--- a/src/test/java/io/vlingo/xoom/lattice/query/FailingStateStore.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/FailingStateStore.java
@@ -1,0 +1,69 @@
+package io.vlingo.xoom.lattice.query;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.common.Failure;
+import io.vlingo.xoom.reactivestreams.Stream;
+import io.vlingo.xoom.symbio.Entry;
+import io.vlingo.xoom.symbio.Metadata;
+import io.vlingo.xoom.symbio.Source;
+import io.vlingo.xoom.symbio.store.QueryExpression;
+import io.vlingo.xoom.symbio.store.Result;
+import io.vlingo.xoom.symbio.store.StorageException;
+import io.vlingo.xoom.symbio.store.state.StateStore;
+import io.vlingo.xoom.symbio.store.state.StateStoreEntryReader;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FailingStateStore implements StateStore {
+
+  private final StateStore delegate;
+  private final AtomicInteger readCount = new AtomicInteger(0);
+  private final AtomicInteger expectedReadFailures = new AtomicInteger(0);
+
+  public FailingStateStore(StateStore delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void read(String id, Class type, ReadResultInterest interest, Object object) {
+    if (readCount.incrementAndGet() > expectedReadFailures.get()) {
+      delegate.read(id, type, interest, object);
+    } else {
+      interest.readResultedIn(Failure.of(new StorageException(Result.NotFound, "Not found.")), id, null, -1, null, object);
+    }
+  }
+
+  @Override
+  public void readAll(Collection collection, ReadResultInterest interest, Object object) {
+    readCount.incrementAndGet();
+    delegate.readAll(collection, interest, object);
+  }
+
+  @Override
+  public Completes<Stream> streamAllOf(Class stateType) {
+    readCount.incrementAndGet();
+    return delegate.streamAllOf(stateType);
+  }
+
+  @Override
+  public Completes<Stream> streamSomeUsing(QueryExpression query) {
+    readCount.incrementAndGet();
+    return delegate.streamSomeUsing(query);
+  }
+
+  @Override
+  public <ET extends Entry<?>> Completes<StateStoreEntryReader<ET>> entryReader(String s) {
+    return delegate.entryReader(s);
+  }
+
+  @Override
+  public <S, C> void write(String s, S s1, int i, List<Source<C>> list, Metadata metadata, WriteResultInterest writeResultInterest, Object o) {
+    delegate.write(s, s1, i, list, metadata, writeResultInterest, o);
+  }
+
+  public void expectReadFailures(Integer count) {
+    expectedReadFailures.set(count);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/lattice/query/FailingStateStore.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/FailingStateStore.java
@@ -22,12 +22,12 @@ public class FailingStateStore implements StateStore {
   private final AtomicInteger readCount = new AtomicInteger(0);
   private final AtomicInteger expectedReadFailures = new AtomicInteger(0);
 
-  public FailingStateStore(StateStore delegate) {
+  public FailingStateStore(final StateStore delegate) {
     this.delegate = delegate;
   }
 
   @Override
-  public void read(String id, Class type, ReadResultInterest interest, Object object) {
+  public void read(final String id, final Class type, final ReadResultInterest interest, final Object object) {
     if (readCount.incrementAndGet() > expectedReadFailures.get()) {
       delegate.read(id, type, interest, object);
     } else {
@@ -36,34 +36,34 @@ public class FailingStateStore implements StateStore {
   }
 
   @Override
-  public void readAll(Collection collection, ReadResultInterest interest, Object object) {
+  public void readAll(final Collection collection, final ReadResultInterest interest, final Object object) {
     readCount.incrementAndGet();
     delegate.readAll(collection, interest, object);
   }
 
   @Override
-  public Completes<Stream> streamAllOf(Class stateType) {
+  public Completes<Stream> streamAllOf(final Class stateType) {
     readCount.incrementAndGet();
     return delegate.streamAllOf(stateType);
   }
 
   @Override
-  public Completes<Stream> streamSomeUsing(QueryExpression query) {
+  public Completes<Stream> streamSomeUsing(final QueryExpression query) {
     readCount.incrementAndGet();
     return delegate.streamSomeUsing(query);
   }
 
   @Override
-  public <ET extends Entry<?>> Completes<StateStoreEntryReader<ET>> entryReader(String s) {
+  public <ET extends Entry<?>> Completes<StateStoreEntryReader<ET>> entryReader(final String s) {
     return delegate.entryReader(s);
   }
 
   @Override
-  public <S, C> void write(String s, S s1, int i, List<Source<C>> list, Metadata metadata, WriteResultInterest writeResultInterest, Object o) {
+  public <S, C> void write(final String s, final S s1, final int i, final List<Source<C>> list, final Metadata metadata, final WriteResultInterest writeResultInterest, final Object o) {
     delegate.write(s, s1, i, list, metadata, writeResultInterest, o);
   }
 
-  public void expectReadFailures(Integer count) {
+  public void expectReadFailures(final Integer count) {
     expectedReadFailures.set(count);
   }
 }

--- a/src/test/java/io/vlingo/xoom/lattice/query/StateStoreQueryActorTest.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/StateStoreQueryActorTest.java
@@ -157,6 +157,42 @@ public class StateStoreQueryActorTest {
     assertEquals(TestState.MISSING, testState.name);
   }
 
+  @Test
+  public void itFindsObjectStateByIdAndTypeAfterRetries() {
+    givenTestState("1", "Foo");
+    givenStateReadFailures(3);
+
+    ObjectState<TestState> testState = queries.testObjectStateById("1", 100, 3).await(500);
+
+    assertEquals(true, testState.isObject());
+    assertEquals("Foo", ((TestState)testState.data).name);
+  }
+
+  @Test
+  public void itFindsObjectStateByIdAndTypeWithNotFoundStateAfterRetries() {
+    givenTestState("1", "Foo");
+    givenStateReadFailures(3);
+
+    ObjectState<TestState> notFoundState = new ObjectState();
+
+    ObjectState<TestState> testState = queries.testObjectStateById("1", notFoundState, 100, 3).await(500);
+
+    assertEquals(true, testState.isObject());
+    assertEquals("Foo", ((TestState)testState.data).name);
+  }
+
+  @Test
+  public void itReturnsNullObjectStateIfStateIsNotFoundByIdAndTypeAfterRetries() {
+    givenTestState("1", "Foo");
+    givenStateReadFailures(3);
+
+    ObjectState<TestState> notFoundState = new ObjectState();
+
+    ObjectState<TestState> testState = queries.testObjectStateById("1", notFoundState, 100, 2).await(500);
+
+    assertEquals(notFoundState, testState);
+  }
+
   @Before
   public void init() {
     TestWorld.startWithDefaults("test-state-store-query");

--- a/src/test/java/io/vlingo/xoom/lattice/query/StateStoreQueryActorTest.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/StateStoreQueryActorTest.java
@@ -1,0 +1,160 @@
+package io.vlingo.xoom.lattice.query;
+
+import io.vlingo.xoom.actors.World;
+import io.vlingo.xoom.actors.testkit.TestWorld;
+import io.vlingo.xoom.common.Outcome;
+import io.vlingo.xoom.lattice.model.stateful.StatefulTypeRegistry;
+import io.vlingo.xoom.lattice.query.fixtures.store.TestQueries;
+import io.vlingo.xoom.lattice.query.fixtures.store.TestQueriesActor;
+import io.vlingo.xoom.lattice.query.fixtures.store.TestState;
+import io.vlingo.xoom.symbio.Source;
+import io.vlingo.xoom.symbio.State.ObjectState;
+import io.vlingo.xoom.symbio.store.Result;
+import io.vlingo.xoom.symbio.store.StorageException;
+import io.vlingo.xoom.symbio.store.dispatch.NoOpDispatcher;
+import io.vlingo.xoom.symbio.store.state.StateStore;
+import io.vlingo.xoom.symbio.store.state.inmemory.InMemoryStateStoreActor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class StateStoreQueryActorTest {
+  private World world;
+  private StateStore stateStore;
+  private TestQueries queries;
+
+  @Test
+  public void itFindsStateByIdAndType() {
+    givenTestState("1", "Foo");
+
+    TestState testState = queries.testStateById("1").await(100);
+
+    assertEquals("Foo", testState.name);
+  }
+
+  @Test
+  public void itReturnsNullIfStateIsNotFoundByIdAndType() {
+    TestState testState = queries.testStateById("1").await(100);
+
+    assertEquals(null, testState);
+  }
+
+  @Test
+  public void itFindsStateByIdAndTypeWithNotFoundState() {
+    givenTestState("1", "Foo");
+
+    TestState testState = queries.testStateById("1", TestState.missing()).await(100);
+
+    assertEquals("Foo", testState.name);
+  }
+
+  @Test
+  public void itReturnsNotFoundStateIfStateIsNotFoundByIdAndType() {
+    TestState testState = queries.testStateById("1", TestState.missing()).await(100);
+
+    assertEquals(TestState.MISSING, testState.name);
+  }
+
+  @Test
+  public void itFindsObjectStateByIdAndType() {
+    givenTestState("1", "Foo");
+
+    ObjectState<TestState> testState = queries.testObjectStateById("1").await(100);
+
+    assertEquals(true, testState.isObject());
+    assertEquals("Foo", ((TestState)testState.data).name);
+  }
+
+  @Test
+  public void itReturnsNullObjectStateIfNotFoundByIdAndType() {
+    ObjectState<TestState> testState = queries.testObjectStateById("1").await(100);
+
+    assertEquals(ObjectState.Null, testState);
+  }
+
+  @Test
+  public void itFindsObjectStateByIdAndTypeWithNotFoundObjectState() {
+    givenTestState("1", "Foo");
+
+    ObjectState<TestState> notFoundState = new ObjectState();
+
+    ObjectState<TestState> testState = queries.testObjectStateById("1", notFoundState).await(100);
+
+    assertEquals(true, testState.isObject());
+    assertEquals("Foo", ((TestState)testState.data).name);
+  }
+
+  @Test
+  public void itReturnsNullObjectStateIfNotFoundByIdAndTypeWithNotFoundObjectState() {
+    ObjectState<TestState> notFoundState = new ObjectState();
+
+    ObjectState<TestState> testState = queries.testObjectStateById("1", notFoundState).await(100);
+
+    assertEquals(notFoundState, testState);
+  }
+
+  @Test
+  public void itStreamsAllStatesByType() {
+    givenTestState("1", "Foo");
+    givenTestState("2", "Bar");
+    givenTestState("3", "Baz");
+    givenTestState("4", "Bam");
+
+    List<TestState> allStates = new ArrayList<>();
+    List<TestState> testStates = queries.all(allStates).await(100);
+
+    assertEquals(4, allStates.size());
+    assertEquals(4, testStates.size());
+    assertEquals(allStates, testStates);
+    assertEquals("Foo", testStates.get(0).name);
+    assertEquals("Bar", testStates.get(1).name);
+    assertEquals("Baz", testStates.get(2).name);
+    assertEquals("Bam", testStates.get(3).name);
+  }
+
+  @Test
+  public void itStreamsEmptyStore() {
+    List<TestState> allStates = new ArrayList<>();
+    List<TestState> testStates = queries.all(allStates).await(100);
+
+    assertEquals(0, allStates.size());
+    assertEquals(0, testStates.size());
+  }
+
+  @Before
+  public void init() {
+    TestWorld.startWithDefaults("test-state-store-query");
+    world = World.startWithDefaults("test-state-store-query");
+    stateStore = world.actorFor(StateStore.class, InMemoryStateStoreActor.class, Arrays.asList(new NoOpDispatcher()));
+    StatefulTypeRegistry.registerAll(world, stateStore, TestState.class);
+    queries = world.actorFor(TestQueries.class, TestQueriesActor.class, stateStore);
+  }
+
+  @After
+  public void shutdown() {
+    if (world != null) {
+      world.terminate();
+    }
+  }
+
+  private void givenTestState(String id, String name) {
+    stateStore.write(
+            id,
+            TestState.named(name),
+            1,
+            new NoOpWriteResultInterest()
+    );
+  }
+
+  private class NoOpWriteResultInterest implements StateStore.WriteResultInterest {
+    @Override
+    public <S, C> void writeResultedIn(Outcome<StorageException, Result> outcome, String s, S s1, int i, List<Source<C>> list, Object o) {
+    }
+  }
+}

--- a/src/test/java/io/vlingo/xoom/lattice/query/StateStoreQueryActorTest.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/StateStoreQueryActorTest.java
@@ -195,8 +195,7 @@ public class StateStoreQueryActorTest {
 
   @Before
   public void init() {
-    TestWorld.startWithDefaults("test-state-store-query");
-    world = World.startWithDefaults("test-state-store-query");
+    world = TestWorld.startWithDefaults("test-state-store-query").world();
     stateStore = new FailingStateStore(world.actorFor(StateStore.class, InMemoryStateStoreActor.class, Arrays.asList(new NoOpDispatcher())));
     StatefulTypeRegistry.registerAll(world, stateStore, TestState.class);
     queries = world.actorFor(TestQueries.class, TestQueriesActor.class, stateStore);

--- a/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueries.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueries.java
@@ -18,5 +18,9 @@ public interface TestQueries {
 
   Completes<ObjectState<TestState>> testObjectStateById(final String id, final ObjectState<TestState> notFoundState);
 
+  Completes<ObjectState<TestState>> testObjectStateById(final String id, final int retryInterval, final int retryCount);
+
+  Completes<ObjectState<TestState>> testObjectStateById(final String id, final ObjectState<TestState> notFoundState, final int retryInterval, final int retryCount);
+
   Completes<Collection<TestState>> all(final Collection<TestState> all);
 }

--- a/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueries.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueries.java
@@ -1,0 +1,18 @@
+package io.vlingo.xoom.lattice.query.fixtures.store;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.symbio.State.ObjectState;
+
+import java.util.Collection;
+
+public interface TestQueries {
+  Completes<TestState> testStateById(final String id);
+
+  Completes<TestState> testStateById(final String id, final TestState notFoundState);
+
+  Completes<ObjectState<TestState>> testObjectStateById(final String id);
+
+  Completes<ObjectState<TestState>> testObjectStateById(final String id, final ObjectState<TestState> notFoundState);
+
+  Completes<Collection<TestState>> all(final Collection<TestState> all);
+}

--- a/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueries.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueries.java
@@ -10,6 +10,10 @@ public interface TestQueries {
 
   Completes<TestState> testStateById(final String id, final TestState notFoundState);
 
+  Completes<TestState> testStateById(final String id, final int retryInterval, final int retryCount);
+
+  Completes<TestState> testStateById(final String id, final TestState notFoundState, final int retryInterval, final int retryCount);
+
   Completes<ObjectState<TestState>> testObjectStateById(final String id);
 
   Completes<ObjectState<TestState>> testObjectStateById(final String id, final ObjectState<TestState> notFoundState);

--- a/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueriesActor.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueriesActor.java
@@ -12,18 +12,22 @@ public class TestQueriesActor extends StateStoreQueryActor implements TestQuerie
     super(stateStore);
   }
 
+  @Override
   public Completes<TestState> testStateById(final String id) {
     return queryStateFor(id, TestState.class);
   }
 
+  @Override
   public Completes<TestState> testStateById(final String id, final TestState notFoundState) {
     return queryStateFor(id, TestState.class, notFoundState);
   }
 
+  @Override
   public Completes<TestState> testStateById(final String id, final int retryInterval, final int retryCount) {
     return queryStateWithRetriesFor(id, TestState.class, retryInterval, retryCount);
   }
 
+  @Override
   public Completes<TestState> testStateById(final String id, final TestState notFoundState, final int retryInterval, final int retryCount) {
     return queryStateWithRetriesFor(id, TestState.class, notFoundState, retryInterval, retryCount);
   }
@@ -36,6 +40,16 @@ public class TestQueriesActor extends StateStoreQueryActor implements TestQuerie
   @Override
   public Completes<ObjectState<TestState>> testObjectStateById(String id, ObjectState<TestState> notFoundState) {
     return queryObjectStateFor(id, TestState.class, notFoundState);
+  }
+
+  @Override
+  public Completes<ObjectState<TestState>> testObjectStateById(final String id, final int retryInterval, final int retryCount) {
+    return queryObjectStateWithRetriesFor(id, TestState.class, retryInterval, retryCount);
+  }
+
+  @Override
+  public Completes<ObjectState<TestState>> testObjectStateById(final String id, final ObjectState<TestState> notFoundState, final int retryInterval, final int retryCount) {
+    return queryObjectStateWithRetriesFor(id, TestState.class, notFoundState, retryInterval, retryCount);
   }
 
   @Override

--- a/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueriesActor.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueriesActor.java
@@ -24,12 +24,12 @@ public class TestQueriesActor extends StateStoreQueryActor implements TestQuerie
 
   @Override
   public Completes<TestState> testStateById(final String id, final int retryInterval, final int retryCount) {
-    return queryStateWithRetriesFor(id, TestState.class, retryInterval, retryCount);
+    return queryStateFor(id, TestState.class, retryInterval, retryCount);
   }
 
   @Override
   public Completes<TestState> testStateById(final String id, final TestState notFoundState, final int retryInterval, final int retryCount) {
-    return queryStateWithRetriesFor(id, TestState.class, notFoundState, retryInterval, retryCount);
+    return queryStateFor(id, TestState.class, notFoundState, retryInterval, retryCount);
   }
 
   @Override
@@ -44,12 +44,12 @@ public class TestQueriesActor extends StateStoreQueryActor implements TestQuerie
 
   @Override
   public Completes<ObjectState<TestState>> testObjectStateById(final String id, final int retryInterval, final int retryCount) {
-    return queryObjectStateWithRetriesFor(id, TestState.class, retryInterval, retryCount);
+    return queryObjectStateFor(id, TestState.class, retryInterval, retryCount);
   }
 
   @Override
   public Completes<ObjectState<TestState>> testObjectStateById(final String id, final ObjectState<TestState> notFoundState, final int retryInterval, final int retryCount) {
-    return queryObjectStateWithRetriesFor(id, TestState.class, notFoundState, retryInterval, retryCount);
+    return queryObjectStateFor(id, TestState.class, notFoundState, retryInterval, retryCount);
   }
 
   @Override

--- a/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueriesActor.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueriesActor.java
@@ -1,0 +1,38 @@
+package io.vlingo.xoom.lattice.query.fixtures.store;
+
+import io.vlingo.xoom.common.Completes;
+import io.vlingo.xoom.lattice.query.StateStoreQueryActor;
+import io.vlingo.xoom.symbio.State;
+import io.vlingo.xoom.symbio.State.ObjectState;
+import io.vlingo.xoom.symbio.store.state.StateStore;
+
+import java.util.Collection;
+
+public class TestQueriesActor extends StateStoreQueryActor implements TestQueries {
+  public TestQueriesActor(StateStore stateStore) {
+    super(stateStore);
+  }
+
+  public Completes<TestState> testStateById(final String id) {
+    return queryStateFor(id, TestState.class);
+  }
+
+  public Completes<TestState> testStateById(final String id, final TestState notFoundState) {
+    return queryStateFor(id, TestState.class, notFoundState);
+  }
+
+  @Override
+  public Completes<ObjectState<TestState>> testObjectStateById(String id) {
+    return queryObjectStateFor(id, TestState.class);
+  }
+
+  @Override
+  public Completes<ObjectState<TestState>> testObjectStateById(String id, ObjectState<TestState> notFoundState) {
+    return queryObjectStateFor(id, TestState.class, notFoundState);
+  }
+
+  @Override
+  public Completes<Collection<TestState>> all(final Collection<TestState> all) {
+    return streamAllOf(TestState.class, all);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueriesActor.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueriesActor.java
@@ -33,12 +33,12 @@ public class TestQueriesActor extends StateStoreQueryActor implements TestQuerie
   }
 
   @Override
-  public Completes<ObjectState<TestState>> testObjectStateById(String id) {
+  public Completes<ObjectState<TestState>> testObjectStateById(final String id) {
     return queryObjectStateFor(id, TestState.class);
   }
 
   @Override
-  public Completes<ObjectState<TestState>> testObjectStateById(String id, ObjectState<TestState> notFoundState) {
+  public Completes<ObjectState<TestState>> testObjectStateById(final String id, final ObjectState<TestState> notFoundState) {
     return queryObjectStateFor(id, TestState.class, notFoundState);
   }
 

--- a/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueriesActor.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestQueriesActor.java
@@ -2,7 +2,6 @@ package io.vlingo.xoom.lattice.query.fixtures.store;
 
 import io.vlingo.xoom.common.Completes;
 import io.vlingo.xoom.lattice.query.StateStoreQueryActor;
-import io.vlingo.xoom.symbio.State;
 import io.vlingo.xoom.symbio.State.ObjectState;
 import io.vlingo.xoom.symbio.store.state.StateStore;
 
@@ -19,6 +18,14 @@ public class TestQueriesActor extends StateStoreQueryActor implements TestQuerie
 
   public Completes<TestState> testStateById(final String id, final TestState notFoundState) {
     return queryStateFor(id, TestState.class, notFoundState);
+  }
+
+  public Completes<TestState> testStateById(final String id, final int retryInterval, final int retryCount) {
+    return queryStateWithRetriesFor(id, TestState.class, retryInterval, retryCount);
+  }
+
+  public Completes<TestState> testStateById(final String id, final TestState notFoundState, final int retryInterval, final int retryCount) {
+    return queryStateWithRetriesFor(id, TestState.class, notFoundState, retryInterval, retryCount);
   }
 
   @Override

--- a/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestState.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestState.java
@@ -1,0 +1,18 @@
+package io.vlingo.xoom.lattice.query.fixtures.store;
+
+public class TestState {
+  public static final String MISSING = "(missing)";
+  public final String name;
+
+  private TestState(String name) {
+    this.name = name;
+  }
+
+  public static TestState named(String name) {
+    return new TestState(name);
+  }
+
+  public static TestState missing() {
+    return new TestState(MISSING);
+  }
+}

--- a/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestState.java
+++ b/src/test/java/io/vlingo/xoom/lattice/query/fixtures/store/TestState.java
@@ -4,11 +4,11 @@ public class TestState {
   public static final String MISSING = "(missing)";
   public final String name;
 
-  private TestState(String name) {
+  private TestState(final String name) {
     this.name = name;
   }
 
-  public static TestState named(String name) {
+  public static TestState named(final String name) {
     return new TestState(name);
   }
 


### PR DESCRIPTION
This PR enables implementations of `StateStoreQueryActor` to retry queries a given number of times in given intervals.

Example use:

```java
public class TestQueriesActor extends StateStoreQueryActor implements TestQueries {
  public TestQueriesActor(StateStore stateStore) {
    super(stateStore);
  }

  @Override
  public Completes<TestState> testStateById(final String id) {
    return queryStateFor(id, TestState.class, 500, 3);
  }

  @Override
  public Completes<TestState> testStateById(final String id, final TestState notFoundState) {
    return queryStateFor(id, TestState.class, notFoundState, 500, 3);
  }

  @Override
  public Completes<ObjectState<TestState>> testObjectStateById(final String id) {
    return queryObjectStateFor(id, TestState.class, 500, 3);
  }

  @Override
  public Completes<ObjectState<TestState>> testObjectStateById(final String id, final ObjectState<TestState> notFoundState) {
    return queryObjectStateFor(id, TestState.class, notFoundState, 500, 3);
  }
}
```

As a bonus, I retrospectively covered `StateStoreQueryActor` with tests to both learn about the internals and make sure the existing behaviour wasn't changed.