### PR TITLE
Instant dispatching incoming and outgoing messages when cluster is healthy

### DIFF
--- a/src/main/java/io/vlingo/xoom/lattice/grid/Grid.java
+++ b/src/main/java/io/vlingo/xoom/lattice/grid/Grid.java
@@ -212,7 +212,6 @@ public class Grid extends Stage implements GridRuntime {
               address,
               GridActorOperations.supplyRelocationSnapshot(actor) /*actor.provideRelocationSnapshot()*/,
               GridActorOperations.pending(actor));
-      outbound.disburse(toNode);
     }
   }
 

--- a/src/main/java/io/vlingo/xoom/lattice/grid/GridNode.java
+++ b/src/main/java/io/vlingo/xoom/lattice/grid/GridNode.java
@@ -155,10 +155,7 @@ public class GridNode extends ClusterApplicationAdapter {
   @Override
   public void informNodeIsHealthy(final Id nodeId, final boolean isHealthyCluster) {
     logger().debug("GRID: Node reported healthy: " + nodeId + " and is healthy: " + isHealthyCluster);
-    if (isHealthyCluster) {
-      outbound.disburse(nodeId);
-      applicationMessageHandler.disburse(nodeId);
-    }
+    outbound.informNodeIsHealthy(nodeId, isHealthyCluster);
   }
 
   @Override

--- a/src/main/java/io/vlingo/xoom/lattice/grid/GridNode.java
+++ b/src/main/java/io/vlingo/xoom/lattice/grid/GridNode.java
@@ -156,6 +156,7 @@ public class GridNode extends ClusterApplicationAdapter {
   public void informNodeIsHealthy(final Id nodeId, final boolean isHealthyCluster) {
     logger().debug("GRID: Node reported healthy: " + nodeId + " and is healthy: " + isHealthyCluster);
     outbound.informNodeIsHealthy(nodeId, isHealthyCluster);
+    applicationMessageHandler.informNodeIsHealthy(nodeId, isHealthyCluster);
   }
 
   @Override
@@ -167,6 +168,8 @@ public class GridNode extends ClusterApplicationAdapter {
   @Override
   public void informNodeLeftCluster(final Id nodeId, final boolean isHealthyCluster) {
     logger().debug("GRID: Node left: " + nodeId + " and is healthy: " + isHealthyCluster);
+    outbound.informNodeIsHealthy(nodeId, isHealthyCluster);
+    applicationMessageHandler.informNodeIsHealthy(nodeId, isHealthyCluster);
     gridRuntime.hashRing().excludeNode(nodeId);
     retryUnAckMessagesOn(nodeId);
   }

--- a/src/main/java/io/vlingo/xoom/lattice/grid/InboundGridActorControl.java
+++ b/src/main/java/io/vlingo/xoom/lattice/grid/InboundGridActorControl.java
@@ -168,8 +168,8 @@ public class InboundGridActorControl extends Actor implements GridActorControl.I
   }
 
   @Override
-  public void disburse(final Id id) {
-    throw new UnsupportedOperationException("disburse of buffered messages handled in ApplicationMessageHandler");
+  public void informNodeIsHealthy(Id id, boolean isHealthy) {
+    throw new UnsupportedOperationException("informNodeIsHealthy handled in ApplicationMessageHandler");
   }
 
   public static class InboundGridActorControlInstantiator implements ActorInstantiator<InboundGridActorControl> {

--- a/src/main/java/io/vlingo/xoom/lattice/grid/application/ApplicationMessageHandler.java
+++ b/src/main/java/io/vlingo/xoom/lattice/grid/application/ApplicationMessageHandler.java
@@ -13,4 +13,6 @@ import io.vlingo.xoom.wire.node.Id;
 public interface ApplicationMessageHandler {
 
   void handle(final RawMessage message);
+
+  void informNodeIsHealthy(final Id id, final boolean isHealthy);
 }

--- a/src/main/java/io/vlingo/xoom/lattice/grid/application/ApplicationMessageHandler.java
+++ b/src/main/java/io/vlingo/xoom/lattice/grid/application/ApplicationMessageHandler.java
@@ -13,6 +13,4 @@ import io.vlingo.xoom.wire.node.Id;
 public interface ApplicationMessageHandler {
 
   void handle(final RawMessage message);
-
-  void disburse(final Id id);
 }

--- a/src/main/java/io/vlingo/xoom/lattice/grid/application/GridActorControl.java
+++ b/src/main/java/io/vlingo/xoom/lattice/grid/application/GridActorControl.java
@@ -52,7 +52,7 @@ public interface GridActorControl {
           final Object snapshot,
           final List<? extends io.vlingo.xoom.actors.Message> pending);
 
-  void disburse(final Id id);
+  void informNodeIsHealthy(final Id id, boolean isHealthy);
 
   interface Inbound extends GridActorControl {
   }

--- a/src/main/java/io/vlingo/xoom/lattice/grid/application/GridApplicationMessageHandler.java
+++ b/src/main/java/io/vlingo/xoom/lattice/grid/application/GridApplicationMessageHandler.java
@@ -7,34 +7,25 @@
 
 package io.vlingo.xoom.lattice.grid.application;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Queue;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.vlingo.xoom.actors.Address;
 import io.vlingo.xoom.actors.LocalMessage;
 import io.vlingo.xoom.actors.Returns;
 import io.vlingo.xoom.common.Completes;
 import io.vlingo.xoom.common.Scheduler;
-import io.vlingo.xoom.lattice.grid.application.message.Answer;
-import io.vlingo.xoom.lattice.grid.application.message.Decoder;
-import io.vlingo.xoom.lattice.grid.application.message.Deliver;
-import io.vlingo.xoom.lattice.grid.application.message.Message;
-import io.vlingo.xoom.lattice.grid.application.message.Relocate;
-import io.vlingo.xoom.lattice.grid.application.message.Start;
-import io.vlingo.xoom.lattice.grid.application.message.Visitor;
+import io.vlingo.xoom.lattice.grid.application.message.*;
 import io.vlingo.xoom.lattice.grid.application.message.serialization.JavaObjectDecoder;
 import io.vlingo.xoom.lattice.grid.hashring.HashRing;
 import io.vlingo.xoom.lattice.util.HardRefHolder;
-import io.vlingo.xoom.lattice.util.WeakQueue;
 import io.vlingo.xoom.wire.message.RawMessage;
 import io.vlingo.xoom.wire.node.Id;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 public final class GridApplicationMessageHandler implements ApplicationMessageHandler {
 
@@ -92,18 +83,11 @@ public final class GridApplicationMessageHandler implements ApplicationMessageHa
         holder.holdOnTo(runnable);
       }
 
-      // incoming messages are dispatched immediately
-      runnable.run();
+      runnable.run(); // incoming messages are dispatched immediately
     } catch (Exception e) {
       logger.error(String.format("Failed to process message %s", raw), e);
     }
   }
-
-  @Override
-  public void disburse(final Id id) {
-    // there are no buffered messages to be disbursed since incoming messages are dispatched immediately
-  }
-
 
   final class ControlMessageVisitor implements Visitor {
     @Override


### PR DESCRIPTION
When cluster is healthy incoming and outgoing messages are dispatched immediately.
When cluster is not healthy, both incoming and outgoing messages are buffered until cluster reaches back healthy state.