### PR TITLE
Send a single confirmation once all projections have finished

### DIFF
--- a/src/main/java/io/vlingo/xoom/lattice/model/projection/MultiConfirmingProjectionControlActor.java
+++ b/src/main/java/io/vlingo/xoom/lattice/model/projection/MultiConfirmingProjectionControlActor.java
@@ -65,7 +65,7 @@ public class MultiConfirmingProjectionControlActor extends Actor implements Mult
 
     final int total = confirmable.total + 1;
 
-    if (confirmable.count < total) {
+    if (confirmable.count > total) {
       confirmables.put(projectionId, confirmable.incrementTotal());
     } else {
       ProjectionControl.confirmerFor(confirmable.projectable, projectionControl).confirm();

--- a/src/test/java/io/vlingo/xoom/lattice/model/projection/JournalProjectionDispatcherTest.java
+++ b/src/test/java/io/vlingo/xoom/lattice/model/projection/JournalProjectionDispatcherTest.java
@@ -235,6 +235,7 @@ public class JournalProjectionDispatcherTest {
         case "TwoHappened":
         case "ThreeHappened":
           accessHolder.accessProjection.writeUsing(AccessProjection, 1);
+          ProjectionControl.confirmerFor(projectable, control).confirm();
           logger().debug("ALL " + (++count));
           break;
         default:

--- a/src/test/java/io/vlingo/xoom/lattice/model/projection/JournalProjectionDispatcherTest.java
+++ b/src/test/java/io/vlingo/xoom/lattice/model/projection/JournalProjectionDispatcherTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -128,6 +129,10 @@ public class JournalProjectionDispatcherTest {
     appendInterest = world.stage().actorFor(AppendResultInterest.class, JournalAppendResultInterest.class);
   }
 
+  @After
+  public void tearDown() {
+    world.terminate();
+  }
 
   private static class AccessHolder {
     private AccessSafely accessJournal;


### PR DESCRIPTION
I stumbled upon this issue while working on another project. I have multiple projections listening to the same event. My tests are failing as the projection confirmation arrives too quickly - before all projections are given a chance to finish.

In the modified code:
* `confirmable.count` is the number of projections the given projectable is sent to. 
* `confirmable.total` is the total of projection confirmations received so far.
* The `confirmable.count < total` is never true, as `count` is always at least 1, and `total` starts at 1. 

Unfortunately, I couldn't write a test case to cover this behaviour as currently there's no access to the projection's dispatcher control. 
